### PR TITLE
realpath to convert environments folder links vs real folder

### DIFF
--- a/simple-php-captcha.php
+++ b/simple-php-captcha.php
@@ -72,7 +72,7 @@ function simple_php_captcha($config = array()) {
 	}
 	
 	// Generate HTML for image src
-	$image_src = substr(__FILE__, strlen($_SERVER['DOCUMENT_ROOT'])) . '?_CAPTCHA&amp;t=' . urlencode(microtime());
+	$image_src = substr(__FILE__, strlen( realpath($_SERVER['DOCUMENT_ROOT']) )) . '?_CAPTCHA&amp;t=' . urlencode(microtime());
 	$image_src = '/' . ltrim(preg_replace('/\\\\/', '/', $image_src), '/');
 	
 	$_SESSION['_CAPTCHA']['config'] = serialize($captcha_config);


### PR DESCRIPTION
On some environments `DOCUMENT_ROOT` is different from the path of `__FILE__`.

The php method `realpath` match them to the same path structure and then `strlen` works as expected.
